### PR TITLE
added pow operation

### DIFF
--- a/main.c
+++ b/main.c
@@ -50,7 +50,7 @@ int precedence(const char* op) {
     switch (*op) {
         case '(': case ')':
             return 1;
-            case '^': case ',':
+        case '^': case ',':
             return 2;
         case '*': case '/':
             return 3;


### PR DESCRIPTION
### Tricky proccess of pow() function:
1. We skip "pow" word as a function.
2. We consider ',' as an operator as a '^', i mean that pow(2,3) is equal to 2^3. I just added ',' as an operator on a 6th place right after '^' operation in inOperations().

Easily work with such expressions like **(sqrt(pow(pow(2, 3), pow(2, 1))) / 4) * 2**
#25